### PR TITLE
support -b for base32 input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ As usual, you can customize the destination with `DESTDIR` and `prefix`.
 
 ## Usage
 
+    $ echo -n JBSWY3DPEHPK3PXP | base32 -d | totp
+    $ 123456
+
+Or
+
+    $ echo JBSWY3DPEHPK3PXP | totp -b
+    $ 123456
+
 It has been thought for [secret](https://github.com/angt/secret),
 maybe it will be directly integrated in a future version, in the meantime:
 

--- a/totp.c
+++ b/totp.c
@@ -120,6 +120,10 @@ base32_decode(uint8_t *inout, size_t len)
 int
 main(int argc, char **argv)
 {
+    if (argc > 1 && argv[1][0] == '-' && argv[1][1] == 'h')
+        return 0 >= printf("Usage: printf SECRET | base32 -d | %s\n"
+                           "       echo   SECRET | %s -b\n", *argv, *argv);
+
     uint8_t h[20];
     uint8_t ki[64 +  8];
     uint8_t ko[64 + 20] = {0};


### PR DESCRIPTION
The title says it all...

(cool project!)

(unrelated, it might be better to replace `echo -n` with `printf %s`, because `echo -n` is non portable, or just remove the `-n` bcause newlines are typically ignored anyway by `base32 -d`).